### PR TITLE
Better order handleing

### DIFF
--- a/Handler/Events.hs
+++ b/Handler/Events.hs
@@ -34,7 +34,7 @@ addOrder morder selectOpt = do
 
     where order = case morder of
             Nothing -> [ Desc EventId ]
-            Just vals -> orderText2SelectOpt $ T.splitOn "," vals
+            Just vals -> textToSelectOptList $ T.splitOn "," vals
 
 getTotalCount :: ( YesodPersist site
                  , YesodPersistBackend site ~ SqlBackend
@@ -58,8 +58,8 @@ addListMetaData urlRender totalCount keyValues =
             ]
 
 
-textToOrder :: Text -> SelectOpt Event
-textToOrder text =
+textToSelectOpt :: Text -> SelectOpt Event
+textToSelectOpt text =
     case textWithNoPrefix of
         "id"    -> direction text $ EventId
         "title" -> direction text $ EventTitle
@@ -75,9 +75,9 @@ textToOrder text =
 
 
 
-orderText2SelectOpt :: [Text] -> [SelectOpt Event]
-orderText2SelectOpt []       = []
-orderText2SelectOpt (x : xs) = [ textToOrder x ] ++ (orderText2SelectOpt xs)
+textToSelectOptList :: [Text] -> [SelectOpt Event]
+textToSelectOptList []       = []
+textToSelectOptList (x : xs) = [ textToSelectOpt x ] ++ (textToSelectOptList xs)
 
 getEventsR :: Handler Value
 getEventsR = do

--- a/Handler/Events.hs
+++ b/Handler/Events.hs
@@ -75,19 +75,22 @@ addListMetaData keyValues = do
 
 text2Order :: Text -> [SelectOpt Event]
 text2Order text =
-  case lookup (text' text) of
+  case lookup textWithNoPrefix keyVal of
     Just val -> [direction val]
     Nothing -> error "wrong order"
   where
-    keyVal = [ ("id"   , EventId)
-             , ("title", EventTitle)
+    keyVal = [ ("title", EventTitle)
+             , ("user" , EventUserId)
+             , ("id"   , EventId)
              ]
-    text' = if T.isPrefixOf "-" text
+
+    textWithNoPrefix = if T.isPrefixOf "-" text
               then T.tail text
               else text
+
     direction = if T.isPrefixOf "-" text
-      then Desc
-      else Asc
+              then Desc
+              else Asc
 
 orderText2SelectOpt :: [Text] -> [SelectOpt Event]
 orderText2SelectOpt []              = []

--- a/Handler/Events.hs
+++ b/Handler/Events.hs
@@ -1,7 +1,7 @@
 module Handler.Events where
 
 import           Data.Aeson
-import qualified Data.Text           as T  (splitOn)
+import qualified Data.Text           as T
 import qualified Data.Text.Read      as T  (decimal)
 import           Handler.Event
 import           Import
@@ -72,6 +72,22 @@ addListMetaData keyValues = do
 
   return $ keyValues ++ metaData
 
+
+text2Order :: Text -> [SelectOpt Event]
+text2Order text =
+  case lookup (text' text) of
+    Just val -> [direction val]
+    Nothing -> error "wrong order"
+  where
+    keyVal = [ ("id"   , EventId)
+             , ("title", EventTitle)
+             ]
+    text' = if T.isPrefixOf "-" text
+              then T.tail text
+              else text
+    direction = if T.isPrefixOf "-" text
+      then Desc
+      else Asc
 
 orderText2SelectOpt :: [Text] -> [SelectOpt Event]
 orderText2SelectOpt []              = []

--- a/Handler/Events.hs
+++ b/Handler/Events.hs
@@ -1,7 +1,7 @@
 module Handler.Events where
 
 import           Data.Aeson
-import qualified Data.Text           as T
+import qualified Data.Text           as T  (isPrefixOf, splitOn, tail)
 import qualified Data.Text.Read      as T  (decimal)
 import           Handler.Event
 import           Import

--- a/Handler/Events.hs
+++ b/Handler/Events.hs
@@ -58,33 +58,26 @@ addListMetaData urlRender totalCount keyValues =
             ]
 
 
+textToOrder :: Text -> SelectOpt Event
+textToOrder text =
+    case textWithNoPrefix of
+        "id"    -> direction text $ EventId
+        "title" -> direction text $ EventTitle
+        "user"  -> direction text $ EventUserId
+        _       -> error "Wrong order"
 
-text2Order :: Text -> [SelectOpt Event]
-text2Order text =
-  case lookup textWithNoPrefix keyVal of
-    Just val -> [direction val]
-    Nothing -> error "wrong order"
-  where
-    keyVal = [ ("title", EventTitle)
-             , ("user" , EventUserId)
-             , ("id"   , EventId)
-             ]
+    where textWithNoPrefix = if T.isPrefixOf "-" text
+                then T.tail text
+                else text
+          direction t = if T.isPrefixOf "-" t
+                    then Desc
+                    else Asc
 
-    textWithNoPrefix = if T.isPrefixOf "-" text
-              then T.tail text
-              else text
 
-    direction = if T.isPrefixOf "-" text
-              then Desc
-              else Asc
 
 orderText2SelectOpt :: [Text] -> [SelectOpt Event]
-orderText2SelectOpt []              = []
-orderText2SelectOpt ("id" : xs)     = [ Asc EventId] ++ (orderText2SelectOpt xs)
-orderText2SelectOpt ("-id" : xs)    = [ Desc EventId] ++ (orderText2SelectOpt xs)
-orderText2SelectOpt ("title" : xs)  = [ Asc EventTitle] ++ (orderText2SelectOpt xs)
-orderText2SelectOpt ("-title" : xs) = [ Desc EventTitle] ++ (orderText2SelectOpt xs)
-orderText2SelectOpt (_ : xs)        = [] ++ (orderText2SelectOpt xs)
+orderText2SelectOpt []       = []
+orderText2SelectOpt (x : xs) = [ textToOrder x ] ++ (orderText2SelectOpt xs)
 
 getEventsR :: Handler Value
 getEventsR = do


### PR DESCRIPTION
Try to generalize the URL handling when going to for example `http://localhost:3000/api/v1.0/events?order=-id,title`

Right now the order is very hardcoded, so we try to move it to a `text2Order` function.